### PR TITLE
Fix deprecated startup config option

### DIFF
--- a/jackett/config.json
+++ b/jackett/config.json
@@ -5,7 +5,7 @@
   "description" : "An addon to add jackett to hassio",
   "url" : "https://github.com/Sabuto/hassio-jackett",
   "arch": ["armv7", "aarch64", "amd64"],
-  "startup": "before",
+  "startup": "application",
   "boot": "auto",
   "webui": "http://[HOST]:[PORT:9118]",
   "map": [


### PR DESCRIPTION
## Fix or Feature Request?

- [x] FIX
- [ ] FEATURE

## If this is a fix has a issue been raised? (anything other than a typo)

- [x] YES `* Please include the issue number or (link)` Fixes #14 
- [ ] NO

## What does this solve

Will remove the log entry in the supervisor 👍 

Adding a comment : i'm not using this addon, it's probably very good 😄 but even when not installed it will pop logs in supervisor.
I'm using your telegraf addon only wich is good too !
